### PR TITLE
Smoke source code changes

### DIFF
--- a/release_notes_v5.0.12
+++ b/release_notes_v5.0.12
@@ -1,0 +1,24 @@
+Release Notes:  RAP v5.0.12
+
+v5.0.12 - released February 16, 2022
+* Crisis fix to address an issue with the smoke pre-processing job.  The current RAP smoke is missing all of the MODIS detections due to the upstream MODIS file name convention change.
+
+
+* Repository Details
+   * Clone the rap.v5.0.12 branch of the RAP GitHub repository using the following command:
+* git clone -b rap.v5.0.12 https://github.com/NOAA-EMC/RAP.git
+
+
+* sorc files changed    
+   * sorc/rap_prep_smoke.fd/process-obs/HRRR-AK-Smoke/src/proc_MODIS_FRP_HRRR-AK.f90
+   * sorc/rap_prep_smoke.fd/process-obs/HRRR-Smoke/src/proc_MODIS_FRP_HRRR_v3.f90
+   * sorc/rap_prep_smoke.fd/process-obs/RAP-Smoke/src/proc_MODIS_FRP_RAP_v3.f90
+
+
+* resource changes
+   * N/A
+
+
+* implementation instructions
+   * Retrieve the new sorc files and re-compile the rap_prep_smoke source code
+

--- a/sorc/rap_prep_smoke.fd/process-obs/HRRR-AK-Smoke/src/proc_MODIS_FRP_HRRR-AK.f90
+++ b/sorc/rap_prep_smoke.fd/process-obs/HRRR-AK-Smoke/src/proc_MODIS_FRP_HRRR-AK.f90
@@ -102,7 +102,7 @@ IMPLICIT NONE
            islash=islash-1
         enddo
         
-        julday = input_modis(29+islash:35+islash)
+        julday = input_modis(31+islash:37+islash)
 ! MAP file in binary and float point
         CALL GETARG(2,lulcmap)
 

--- a/sorc/rap_prep_smoke.fd/process-obs/HRRR-Smoke/src/proc_MODIS_FRP_HRRR_v3.f90
+++ b/sorc/rap_prep_smoke.fd/process-obs/HRRR-Smoke/src/proc_MODIS_FRP_HRRR_v3.f90
@@ -103,7 +103,7 @@ PROGRAM rmodis_hrrr
      islash=islash-1
   enddo
 
-  julday = input_modis(29+islash:35+islash)
+  julday = input_modis(31+islash:37+islash)
   ! MAP file in binary and float point
   CALL GETARG(2,lulcmap)
 

--- a/sorc/rap_prep_smoke.fd/process-obs/RAP-Smoke/src/proc_MODIS_FRP_RAP_v3.f90
+++ b/sorc/rap_prep_smoke.fd/process-obs/RAP-Smoke/src/proc_MODIS_FRP_RAP_v3.f90
@@ -102,7 +102,7 @@ IMPLICIT NONE
            islash=islash-1
         enddo
         
-        julday = input_modis(29+islash:35+islash)
+        julday = input_modis(31+islash:37+islash)
 ! MAP file in binary and float point
         CALL GETARG(2,lulcmap)
 


### PR DESCRIPTION
The current RAP and HRRR-Smoke miss all the MODIS detections, which give critical smoke information in the morning hours. Currently RAP/HRRR have a gap/delay in the fire detections as the system can only ingest the VIIRS data from 2 satellites, both of which are in the afternoon orbits.  This pull request contains the source code changes required by the RAP.