### PR TITLE
WCOSS2 build modules fix

### DIFF
--- a/modulefiles/RAP/v5.0.0
+++ b/modulefiles/RAP/v5.0.0
@@ -1,10 +1,10 @@
 #%Module######################################################################
 ##                                                   Geoffrey.Manikin@noaa.gov
 ##                                                           NOAA/NWS/NCEP/EMC
-## RAP v5.0.0
+## RAP version from build.ver/rap_build_ver 
 ##_____________________________________________________
 
-set ver v5.0.0
+set ver ${rap_build_ver}
 
 set sys [uname sysname]
 set lname HRRR
@@ -19,7 +19,6 @@ export C_COMP_MP=cc
 export C_COMP_MPI=cc
 
 export BASE=`pwd`
-source $BASE/../../versions/build.ver
 
 module purge
 

--- a/sorc/build_rap_all.sh
+++ b/sorc/build_rap_all.sh
@@ -28,14 +28,7 @@ export BUILD_rap_wrfbufr=yes
 export BUILD_rap_stnmlist=yes
 export BUILD_rap_smartinit=yes
 
-
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-
-module list
+source $BASE/build_rap_module_load.sh
 
 mkdir $BASE/logs
 export logs_dir=$BASE/logs

--- a/sorc/build_rap_all_clean.sh
+++ b/sorc/build_rap_all_clean.sh
@@ -28,12 +28,8 @@ export BUILD_rap_wrfbufr=yes
 export BUILD_rap_stnmlist=yes
 export BUILD_rap_smartinit=yes
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
 
-module list
+source $BASE/build_rap_module_load.sh
 
 mkdir $BASE/logs
 export logs_dir=$BASE/logs

--- a/sorc/build_rap_full_cycle_surface.sh
+++ b/sorc/build_rap_full_cycle_surface.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_full_cycle_surface.fd
 make clean

--- a/sorc/build_rap_gsi.sh
+++ b/sorc/build_rap_gsi.sh
@@ -5,9 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
 
-# Load modules
 export COMP=ftn
 export COMP_MP=ftn
 export COMP_MPI=ftn
@@ -20,11 +18,7 @@ set COMPILER intel
 setenv FFLAGS_COM "-fp-model strict"
 setenv LDFLAGS_COM " "
 
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_gsi.fd
 rm -fr build

--- a/sorc/build_rap_module_load.sh
+++ b/sorc/build_rap_module_load.sh
@@ -1,0 +1,10 @@
+set -x
+
+export BASE=`pwd`
+cd $BASE
+
+module reset
+source $BASE/../versions/build.ver
+module use $BASE/../modulefiles
+source $BASE/../modulefiles/RAP/${rap_build_ver}
+module list

--- a/sorc/build_rap_prep_smoke.sh
+++ b/sorc/build_rap_prep_smoke.sh
@@ -3,11 +3,7 @@
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_prep_smoke.fd/process-obs/QC
 make clean

--- a/sorc/build_rap_process_cloud.sh
+++ b/sorc/build_rap_process_cloud.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_cloud.fd
 make clean

--- a/sorc/build_rap_process_enkf.sh
+++ b/sorc/build_rap_process_enkf.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_enkf.fd
 make clean

--- a/sorc/build_rap_process_imssnow.sh
+++ b/sorc/build_rap_process_imssnow.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_imssnow.fd
 make clean

--- a/sorc/build_rap_process_lightning.sh
+++ b/sorc/build_rap_process_lightning.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_lightning.fd
 make clean

--- a/sorc/build_rap_process_mosaic.sh
+++ b/sorc/build_rap_process_mosaic.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_mosaic.fd
 make clean

--- a/sorc/build_rap_process_sst.sh
+++ b/sorc/build_rap_process_sst.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_process_sst.fd
 make clean

--- a/sorc/build_rap_smartinit.sh
+++ b/sorc/build_rap_smartinit.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 sleep 1
 

--- a/sorc/build_rap_sndp.sh
+++ b/sorc/build_rap_sndp.sh
@@ -5,13 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_sndp.fd
 make clean

--- a/sorc/build_rap_stnmlist.sh
+++ b/sorc/build_rap_stnmlist.sh
@@ -5,12 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_stnmlist.fd
 make clean

--- a/sorc/build_rap_subflds_g2.sh
+++ b/sorc/build_rap_subflds_g2.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_subflds_g2.fd
 make clean

--- a/sorc/build_rap_update_bc.sh
+++ b/sorc/build_rap_update_bc.sh
@@ -4,11 +4,7 @@ set -x
 
 export BASE=`pwd`
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_update_bc.fd
 make clean

--- a/sorc/build_rap_update_fields.sh
+++ b/sorc/build_rap_update_fields.sh
@@ -4,11 +4,7 @@ set -x
 
 export BASE=`pwd`
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_update_fields.fd
 make clean

--- a/sorc/build_rap_update_gvf.sh
+++ b/sorc/build_rap_update_gvf.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_update_gvf.fd
 make clean

--- a/sorc/build_rap_wps.sh
+++ b/sorc/build_rap_wps.sh
@@ -4,11 +4,7 @@ set -x
 
 export BASE=`pwd`
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_wps.fd/WPSV3.9.1
 ./clean -aa

--- a/sorc/build_rap_wrfarw.sh
+++ b/sorc/build_rap_wrfarw.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_wrfarw.fd
 

--- a/sorc/build_rap_wrfarw_serial.sh
+++ b/sorc/build_rap_wrfarw_serial.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_wrfarw.fd/WRFV3.9
 ./clean -aa

--- a/sorc/build_rap_wrfbufr.sh
+++ b/sorc/build_rap_wrfbufr.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_wrfbufr.fd
 make clean

--- a/sorc/build_rap_wrfpost.sh
+++ b/sorc/build_rap_wrfpost.sh
@@ -5,11 +5,7 @@ set -x
 export BASE=`pwd`
 cd $BASE
 
-module purge
-module load envvar/1.0
-module use $BASE/../modulefiles
-source $BASE/../modulefiles/RAP/v5.0.0
-module list
+source $BASE/build_rap_module_load.sh
 
 cd ${BASE}/rap_wrfpost.fd
 make clean

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -1,3 +1,4 @@
+export rap_build_ver="v5.0.0"
 export PrgEnv_intel_ver="8.1.0"
 export craype_ver="2.7.10"
 export intel_ver="19.1.3.304"


### PR DESCRIPTION
- Remove version numbers outside versions dir
- update the address to build.ver in module load. 
- Remove module purge and replaced with module reset